### PR TITLE
Update quickstart_guide.md

### DIFF
--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -6,7 +6,8 @@ See [here][github-toc] to learn where to find table of contents.
 1. [Host platform requirements](#I-host-platform-requirements)
     1. [Hardware](#1-hardware)
     2. [Software](#2-software)
-    3. [CloudLab Deployment Notes](#3-cloudlab-deployment-notes)
+    3. Pre-requisites
+    4. [CloudLab Deployment Notes](#3-cloudlab-deployment-notes)
         1. [CloudLab Profile](#a-cloudlab-profile)
         2. [Nodes to Rent](#b-nodes-to-rent)
 2. [Setup a Serverless (Knative) Cluster](#ii-setup-a-serverless-knative-cluster)


### PR DESCRIPTION
## Summary

Minor changes in the quick-start guide for setting up vHive. This includes adding log-file names during setup of 'Single Node Cluster' and a pre-requisite check for KVM.

## Implementation Notes :hammer_and_pick:

* N/A

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
